### PR TITLE
Columns default for grid-push and grid-pull

### DIFF
--- a/stylesheets/960/_grid.sass
+++ b/stylesheets/960/_grid.sass
@@ -61,10 +61,10 @@ $ninesixty-columns: 12 !default
 =grid-move-base
   position: relative
 
-=grid-push($n, $cols)
+=grid-push($n, $cols: $ninesixty-columns)
   left: ($ninesixty-grid-width / $cols) * $n
 
-=grid-pull($n, $cols)
+=grid-pull($n, $cols: $ninesixty-columns)
   left: -($ninesixty-grid-width / $cols) * $n
 
 =grid-movements($cols: $ninesixty-columns)


### PR DESCRIPTION
Made grid-push and grid-pull aware of default number of columns via $ninesixty-columns.
