### PR TITLE
fixed 2 bugs and changed grid-system to generate real 960.gs (all classes)

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -41,14 +41,13 @@ as defaults if the corresponding argument is omitted from a mixin call.
 Class-Based Grid System
 =======================
 
-To create a grid system that works like the original 960 Grid Sytem framework
+To create a grid system that works like the original 960 Grid System framework
 use the `+grid-system` mixin to generate the corresponding classes. You can
 also customize the number of columns as demonstrated in the following example.
 
 Example:
 
-    #wrap
-      +grid-system(24)
+    +grid-system(24)
 
 Making Semantic Grids
 =====================

--- a/stylesheets/960/_grid.sass
+++ b/stylesheets/960/_grid.sass
@@ -81,7 +81,7 @@ $ninesixty-class-separator: "_" !default
   #{enumerate(".push", 1, $cols, $ninesixty-class-separator)},
   #{enumerate(".pull", 1, $cols, $ninesixty-class-separator)}
     +grid-move-base
-  @for $n from 1 through $cols
+  @for $n from 1 through $cols - 1
     .push#{$ninesixty-class-separator}#{$n}
       +grid-move-push($n, $cols)
     .pull#{$ninesixty-class-separator}#{$n}

--- a/stylesheets/960/_grid.sass
+++ b/stylesheets/960/_grid.sass
@@ -33,7 +33,7 @@ $ninesixty-class-separator: "_" !default
 
 =grids($cols: $ninesixty-columns, $gutter-width: $ninesixty-gutter-width)
   #{enumerate(".grid", 1, $cols, $ninesixty-class-separator)}
-    +grid-unit-base
+    +grid-unit-base($gutter-width)
   @for $n from 1 through $cols
     .grid#{$ninesixty-class-separator}#{$n}
       +grid-width($n, $cols, $gutter-width)

--- a/stylesheets/960/_grid.sass
+++ b/stylesheets/960/_grid.sass
@@ -88,9 +88,10 @@ $ninesixty-class-separator: "_" !default
       +grid-move-pull($n, $cols)
 
 =grid-system($cols: $ninesixty-columns)
-  +grid-container
-  +grids($cols)
-  +grid-prefixes($cols)
-  +grid-suffixes($cols)
-  +grid-children
-  +grid-movements($cols)
+  .container#{$ninesixty-class-separator}#{$cols}
+    +grid-container
+    +grids($cols)
+    +grid-prefixes($cols)
+    +grid-suffixes($cols)
+    +grid-children
+    +grid-movements($cols)

--- a/templates/project/grid.sass
+++ b/templates/project/grid.sass
@@ -7,11 +7,10 @@
 @import 960/grid
 
 // The following generates the default grids provided by the css version of 960.gs
-.container_12
-  +grid-system(12)
 
-.container_16
-  +grid-system(16)
++grid-system(12)
+
++grid-system(16)
 
 // But most compass users prefer to construct semantic layouts like so (two column layout with header and footer):
 

--- a/templates/project/grid.sass
+++ b/templates/project/grid.sass
@@ -18,14 +18,9 @@ $ninesixty-columns: 24
 
 .two-column
   +grid-container
-  #header,
-  #footer,
-  #sidebar,
-  #main-content
-    +grid-unit-base
   #header, #footer
-    +grid-width(24)
+    +grid(24)
   #sidebar
-    +grid-width(8)
+    +grid(8)
   #main-content
-    +grid-width(16)
+    +grid(16)


### PR DESCRIPTION
Please consider my small changes for generating in "grid-system" mixin class ".container_XX" to simulate real 960.gs css framework.
However, there are 2 bugs fixed in this pull request. I think their solution will be useful at least.

Thanks for your gem. I've just started to look at haml+css+compass and your gem gave me good lesson for understanding difference between "for + include" and "enumerate + include".
I hope my changes will have sense for you. ;)
