### PR TITLE
second part of removing unneeded last .push and .pull classes

### DIFF
--- a/stylesheets/960/_grid.sass
+++ b/stylesheets/960/_grid.sass
@@ -78,8 +78,8 @@ $ninesixty-class-separator: "_" !default
   +grid-move-pull($n, $cols)
 
 =grid-movements($cols: $ninesixty-columns)
-  #{enumerate(".push", 1, $cols, $ninesixty-class-separator)},
-  #{enumerate(".pull", 1, $cols, $ninesixty-class-separator)}
+  #{enumerate(".push", 1, $cols - 1, $ninesixty-class-separator)},
+  #{enumerate(".pull", 1, $cols - 1, $ninesixty-class-separator)}
     +grid-move-base
   @for $n from 1 through $cols - 1
     .push#{$ninesixty-class-separator}#{$n}


### PR DESCRIPTION
Hi nextmat.

If you remember in discussion about last .push and .pull classes I noted that I had forgotten to add " - 1 " to "enumerate" parts too. And I told that I will do it later.
So, I've done it. ;)
Sorry for delay, I hadn't time to do it earlier.

P.S. I will message you about .container_xx class a little bit later.

P.S.2   I have one question about how to work on github better:
I have this last commit on my master branch. But if I pull request it to you from there (from master) it will pull you request with 5 last commits because they aren't on your master branch. And I couldn't change it behaviour. So I decided just to create new branch from your master branch and do 'git cherry-pick' this last commit from my master branch to have pull request with one commit.
So my question is: Do you know another solution for such cases (to make clear pull request) ?
Thanks in advance.
