### PR TITLE
+alpha and +omega are used only in nested grids and only after +grid(XX)

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -69,13 +69,17 @@ Example:
 
     #wrap
       +grid-container
-      #left-nav
-        +alpha
-        +grid(5)
-      #main-content
-        +grid-prefix(1)
-        +grid(10)
-        +omega
+      #header
+        +grid(16)
+      #middle
+        +grid(16)
+        #left-nav
+          +grid(5)
+          +alpha
+        #main-content
+          +grid-prefix(1)
+          +grid(10)
+          +omega
 
 Authors/Contributors
 ====================


### PR DESCRIPTION
Hi guys.
There is mistake in example in README file.
You use +alpha mixin before +grid mixin. So margin-left=10px from +grid overwrite margin-left=0px from +alpha. There is no sense to use +alpha in such way because it does nothing.
If you use +alpha in your example after +grid, then it will be correct and grid will not have left margin, but then your grid will lie not correctly in a container.
+alpha and +omega are needed only in nested grids to delete left margin of the first nested grid and right margin of the last nested grid   ( of the same nested level ;) ) .
Because of that I've change a little bit example to leave preview of using +alpha and +omega.
